### PR TITLE
Update UnblockMusicHook.java

### DIFF
--- a/app/src/main/java/com/raincat/dolby_beta/hook/UnblockMusicHook.java
+++ b/app/src/main/java/com/raincat/dolby_beta/hook/UnblockMusicHook.java
@@ -50,7 +50,7 @@ public class UnblockMusicHook {
     private String fieldSSLSocketFactory;
 
     private final List<String> whiteUrlList = Arrays.asList(
-            "song/enhance/player/url", "song/enhance/download/url");
+            "song/enhance/player/url", "song/enhance/download/url", "bilivideo.com");
 
     private final List<String> blackUrlList = Arrays.asList("eapi/playlist/subscribe",
             "163yun.com");


### PR DESCRIPTION
使得bilibili音源走unblockneteasemusic代理，以便在白名单模式下使其正常播放(bilibili音源需要添加referer)。