### PR TITLE
更换node，解决原node部分android12闪退问题

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,4 +32,4 @@ jobs:
           name: app-release
           path: ${{github.workspace}}/app/build/outputs/apk/release/*.apk
           if-no-files-found: warn
-          retention-days: 7
+          retention-days: 30


### PR DESCRIPTION
重新编译了V13的node 原版的安卓12会闪退，发现一个bug 网易云8.2.10以上的无法直接跑二进制不知道问题在哪